### PR TITLE
Change readme to reflect plan label change from free to 100 for mongodb service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Getting services from marketplace in org cs-home / space development as [usernam
 OK
 
 service   plans   description
-mongodb   free    MongoDB NoSQL database
+mongodb   100    MongoDB NoSQL database
 
-% cf create-service mongodb free wordplay-mongodb
+% cf create-service mongodb 100 wordplay-mongodb
 Creating service wordplay-mongodb in org cs-home / space development as [username]...
 OK
 


### PR DESCRIPTION
MongoDB service is now listed as 100 under plans. Although it's still free, it's not labeled as free.
