### PR TITLE
[WIP] remove hard-coding of Mongo service name

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -7,8 +7,10 @@ jq=$DIR/jq
 chmod +x $jq
 
 extract_mongo_url() {
+  # Set if not already present.
   if [ -n "${MONGO_URL}" ]
     #echo "Pulling MONGO_URL from VCAP_SERVICES"
+    # Find the first service key that contains "mongo", then grab the 'url' (or 'uri') key beneath it.
     export MONGO_URL=`echo $VCAP_SERVICES | $jq 'to_entries|map(select(.key|contains("mongo")))[0]|.value[0].credentials|if .url then .url else .uri end|. // empty'`
   fi
   #echo "MONGO_URL: $MONGO_URL"

--- a/bin/release
+++ b/bin/release
@@ -7,8 +7,10 @@ jq=$DIR/jq
 chmod +x $jq
 
 extract_mongo_url() {
-  #echo "Pulling MONGO_URL from VCAP_SERVICES"
-  export MONGO_URL=`echo $VCAP_SERVICES | $jq 'to_entries|map(select(.key|contains("mongo")))[0]|.value[0].credentials|if .url then .url else .uri end|. // empty'`
+  if [ -n "${MONGO_URL}" ]
+    #echo "Pulling MONGO_URL from VCAP_SERVICES"
+    export MONGO_URL=`echo $VCAP_SERVICES | $jq 'to_entries|map(select(.key|contains("mongo")))[0]|.value[0].credentials|if .url then .url else .uri end|. // empty'`
+  fi
   #echo "MONGO_URL: $MONGO_URL"
 }
 

--- a/bin/release
+++ b/bin/release
@@ -8,7 +8,7 @@ chmod +x $jq
 
 extract_mongo_url() {
   #echo "Pulling MONGO_URL from VCAP_SERVICES"
-  export MONGO_URL=`echo $VCAP_SERVICES | $jq '."mongodb-new"[0].credentials.uri'`
+  export MONGO_URL=`echo $VCAP_SERVICES | $jq 'to_entries|map(select(.key|contains("mongo")))[0]|.value[0].credentials|if .url then .url else .uri end|. // empty'`
   #echo "MONGO_URL: $MONGO_URL"
 }
 

--- a/bin/release
+++ b/bin/release
@@ -8,7 +8,7 @@ chmod +x $jq
 
 extract_mongo_url() {
   #echo "Pulling MONGO_URL from VCAP_SERVICES"
-  export MONGO_URL=`echo $VCAP_SERVICES | $jq '."mongodb-2.4"[0].credentials.url'`
+  export MONGO_URL=`echo $VCAP_SERVICES | $jq '."mongodb-new"[0].credentials.uri'`
   #echo "MONGO_URL: $MONGO_URL"
 }
 


### PR DESCRIPTION
Fixes #4.

Will now work for any service containing the string "mongo", and won't overwrite the `MONGO_URL` environment variable if it's already set.
- [ ] Test deploying with this branch

/cc @csterwa @jsloyer @dlapiduz @adelevie
