### PR TITLE
Included logic for COUCHDB_URL same as MONGO and ROOT

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -17,10 +17,12 @@ extract_mongo_url() {
 }
 
 extract_root_url() {
-  #echo "Pulling ROOT_URL from VCAP_APPLICATION"
-  DOMAIN=`echo $VCAP_APPLICATION | $jq '.uris[0]' | sed -e 's/^"//'  -e 's/"$//'`
-  export ROOT_URL="http://$DOMAIN"
-  #echo "ROOT_URL: $ROOT_URL"
+  if [ -z "${ROOT_URL}" ]; then
+    #echo "Pulling ROOT_URL from VCAP_APPLICATION"
+    DOMAIN=`echo $VCAP_APPLICATION | $jq '.uris[0]' | sed -e 's/^"//'  -e 's/"$//'`
+    export ROOT_URL="http://$DOMAIN"
+    #echo "ROOT_URL: $ROOT_URL"
+  fi
 }
 
 extract_mongo_url

--- a/bin/release
+++ b/bin/release
@@ -25,8 +25,17 @@ extract_root_url() {
   fi
 }
 
+extract_couchdb_url() {
+  if [ -z "${COUCHDB_URL}" ]; then
+    #echo "Pulling COUCHDB_URL from VCAP_SERVICES"
+    # Find the first service key that contains "cloudant", then grab the 'url' (or 'uri') key beneath it.
+    export COUCHDB_URL=`echo $VCAP_SERVICES | $jq 'to_entries|map(select(.key|contains("cloudant")))[0]|.value[0].credentials|if .url then .url else .uri end|. // empty'`
+  fi
+}
+
 extract_mongo_url
 extract_root_url
+extract_couchdb_url
 
 cat <<-YAML
 ---

--- a/bin/release
+++ b/bin/release
@@ -40,5 +40,5 @@ extract_couchdb_url
 cat <<-YAML
 ---
 default_process_types:
-  web: MONGO_URL=$MONGO_URL ROOT_URL=$ROOT_URL vendor/node/bin/node deploy/bundle/main.js
+  web: MONGO_URL=$MONGO_URL COUCHDB_URL=$COUCHDB_URL ROOT_URL=$ROOT_URL vendor/node/bin/node deploy/bundle/main.js
 YAML


### PR DESCRIPTION
Now that meteor supports cloudant , i added the logic so you dont need to explicitly define the COUCHDB_URL , you can allow the buildpack to pull it from the VCAP_SERVICES the same way mongo and root are derived. 
