### PR TITLE
Fixes for 1.3

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -71,10 +71,12 @@ build() {
   (
     cd $BUILD_DIR
     status "Building meteor bundle"
+    meteor npm config set production
     meteor build --directory deploy --server http://localhost:3000
     cd deploy/bundle/programs/server
     status "Installing npm dependencies"
-    npm install 2>&1 | indent
+
+    meteor npm install 2>&1 | indent
     mv $BUILD_DIR/.vendor $BUILD_DIR/vendor
   )
 }

--- a/bin/compile
+++ b/bin/compile
@@ -71,12 +71,13 @@ build() {
   (
     cd $BUILD_DIR
     status "Building meteor bundle"
+    export METEOR_WATCH_FORCE_POLLING=true
     meteor npm config set production
-    meteor build --directory deploy --server http://localhost:3000
+    meteor build --server-only --directory deploy --server http://localhost:3000
     cd deploy/bundle/programs/server
     status "Installing npm dependencies"
 
-    meteor npm install 2>&1 | indent
+    meteor npm install --production 2>&1 | indent
     mv $BUILD_DIR/.vendor $BUILD_DIR/vendor
   )
 }


### PR DESCRIPTION
This PR helps to support Meteor 1.3 on Bluemix.  It should correct this issue https://github.com/cloudfoundry-community/cf-meteor-buildpack/issues/20.

The trick is to use METEOR_WATCH_FORCE_POLLING to cause Meteor not to use inotify, which consumes file handles.  We have a a limited # on Bluemix.
